### PR TITLE
Edge cases and improved validation

### DIFF
--- a/src/test/kotlin/com/eignex/kencode/TestClasses.kt
+++ b/src/test/kotlin/com/eignex/kencode/TestClasses.kt
@@ -51,7 +51,8 @@ data class NullableFieldsPayload(
     val maybeId: Int?,
     val maybeName: String?,
     val maybeScore: Long?,
-    val maybeFlag: Boolean?
+    val maybeFlag: Boolean?,
+    val maybeList: List<Int>?
 )
 
 @Serializable


### PR DESCRIPTION
This PR improves the robustness of PackedDecoder and closes test coverage gaps.

- Replaces silent fallbacks with strict validations to prevent custom serializers from misusing bitmask states.
- Updates decodeElementIndex to properly yield sequential indices for both classes and collections.
- Adds comprehensive tests for EOF byte truncations, extreme primitives, and nullable collections.